### PR TITLE
Update SoapESP32.cpp

### DIFF
--- a/src/SoapESP32.cpp
+++ b/src/SoapESP32.cpp
@@ -774,8 +774,14 @@ bool SoapESP32::soapScanItem(const String *parentId,
       log_d("uri=\"%s\"", info.uri.c_str());
 
       // scan file size
-      if (!soapScanAttribute(&strAttr, &str, DIDL_ATTR_SIZE)) return false;
-      if ((info.size = (size_t)str.toInt()) == 0) {
+      if (!soapScanAttribute(&strAttr, &str, DIDL_ATTR_SIZE)) {
+          info.size = -1; 
+      } 
+      else {
+        info.size = (size_t)str.toInt();
+      }
+      
+      if (info.size == 0) {
         log_e("file size=0"); 
         // to allow for empty files comment next line out
         return false; // we ignore empty files

--- a/src/SoapESP32.cpp
+++ b/src/SoapESP32.cpp
@@ -775,7 +775,7 @@ bool SoapESP32::soapScanItem(const String *parentId,
 
       // scan file size
       if (!soapScanAttribute(&strAttr, &str, DIDL_ATTR_SIZE)) {
-          info.size = -1; 
+          info.size = SIZE_MAX; 
       } 
       else {
         info.size = (size_t)str.toInt();


### PR DESCRIPTION
For example, the Fritzbox media server does not provide a file length for entries located in the Internet Radio folder because they are streams. If no file length can be determined, -1 is set for the file length.